### PR TITLE
feat: expand spiders to all property types and rental listings

### DIFF
--- a/homyscrapy/spiders/costa_rica/cccbr.py
+++ b/homyscrapy/spiders/costa_rica/cccbr.py
@@ -88,8 +88,12 @@ class CamaraSpider(BasePropertySpider):
         currency = meta.get('moneda') or 'USD'
         if price_sale:
             item['price'] = f'{currency} {price_sale}'.strip()
+            item['status'] = 'sale'
         elif price_rent:
             item['price'] = f'{currency} {price_rent} (alquiler)'.strip()
+            item['status'] = 'rent'
+        else:
+            item['status'] = 'sale'  # default for listings without price info
 
         # Property details
         item['bedrooms'] = str(meta.get('habitaciones') or '')

--- a/homyscrapy/spiders/costa_rica/encuentra24.py
+++ b/homyscrapy/spiders/costa_rica/encuentra24.py
@@ -1,13 +1,21 @@
 import scrapy
-from homyscrapy.items import PropertyItem
 from homyscrapy.spiders.base_spider import BasePropertySpider
 from datetime import datetime, timezone, timedelta
 import os
-import random
 
 _CR_TZ = timezone(timedelta(hours=-6))
 
-BASE_URL = 'https://www.encuentra24.com/costa-rica-es/bienes-raices-venta-de-propiedades-casas'
+# All active listing segments: (base_url, property_category, status)
+# Sale URLs use the per-type pattern: bienes-raices-venta-de-propiedades-{type}
+# Rental URL is a single catch-all: bienes-raices-alquiler (no per-type sub-paths confirmed)
+# property_category for rentals is left to dbt title-based normalization.
+_LISTING_URLS = [
+    ('https://www.encuentra24.com/costa-rica-es/bienes-raices-venta-de-propiedades-casas',              'house',      'sale'),
+    ('https://www.encuentra24.com/costa-rica-es/bienes-raices-venta-de-propiedades-apartamentos',       'apartment',  'sale'),
+    ('https://www.encuentra24.com/costa-rica-es/bienes-raices-venta-de-propiedades-terrenos',           'land',       'sale'),
+    ('https://www.encuentra24.com/costa-rica-es/bienes-raices-venta-de-propiedades-locales-comerciales','commercial', 'sale'),
+    ('https://www.encuentra24.com/costa-rica-es/bienes-raices-alquiler',                                None,         'rent'),
+]
 
 # Standard browser headers — enough to pass Cloudflare without a real browser
 _HEADERS = {
@@ -32,7 +40,7 @@ class Encuentra24Spider(BasePropertySpider):
     Cloudflare browser-fingerprint detection entirely.
 
     Each page has a direct URL: <base>.N (e.g. .../casas.2 for page 2).
-    Scrapy handles pagination by yielding one request per page.
+    All property types and both transaction types (sale and rent) are crawled.
     """
 
     name = 'encuentra24'
@@ -67,9 +75,9 @@ class Encuentra24Spider(BasePropertySpider):
             self.output_date = output_date
         self.logger.info(f"Starting scrape — max_pages: {self.max_pages}, proxy: {'yes' if self._proxy_url else 'no'}, date: {self.output_date}")
 
-    @classmethod
-    def _page_url(cls, page_num):
-        return BASE_URL if page_num == 1 else f'{BASE_URL}.{page_num}'
+    @staticmethod
+    def _page_url(base_url, page_num):
+        return base_url if page_num == 1 else f'{base_url}.{page_num}'
 
     def _meta(self):
         m = {}
@@ -78,49 +86,51 @@ class Encuentra24Spider(BasePropertySpider):
         return m
 
     async def start(self):
-        yield scrapy.Request(
-            self._page_url(1),
-            headers=_HEADERS,
-            meta=self._meta(),
-            callback=self.parse,
-            cb_kwargs={'page_num': 1},
-            errback=self.errback,
-        )
+        for base_url, property_category, status in _LISTING_URLS:
+            self.logger.info(f"Queuing segment: {property_category}/{status}")
+            yield scrapy.Request(
+                self._page_url(base_url, 1),
+                headers=_HEADERS,
+                meta=self._meta(),
+                callback=self.parse,
+                cb_kwargs={'base_url': base_url, 'property_category': property_category, 'status': status, 'page_num': 1},
+                errback=self.errback,
+            )
 
-    def parse(self, response, page_num=1):
+    def parse(self, response, base_url, property_category, status, page_num=1):
         ads = response.css('a.item-card-link')
-        self.logger.info(f"Page {page_num}: {len(ads)} ads found")
+        self.logger.info(f"[{property_category}/{status}] Page {page_num}: {len(ads)} ads found")
 
         if not ads:
-            self.logger.warning(f"Page {page_num}: no ads — stopping.")
+            self.logger.warning(f"[{property_category}/{status}] Page {page_num}: no ads — stopping.")
             return
 
         for ad in ads:
-            item = self._extract_item(ad, response)
+            item = self._extract_item(ad, response, property_category=property_category, status=status)
             if item['url']:
                 yield item
 
         if self.max_pages != 0 and page_num >= self.max_pages:
-            self.logger.info(f"Reached max_pages limit ({self.max_pages})")
+            self.logger.info(f"[{property_category}/{status}] Reached max_pages limit ({self.max_pages})")
             return
 
         next_btn = response.css('button[aria-label="Página siguiente"]')
         if not next_btn or next_btn.attrib.get('aria-disabled') == 'true':
-            self.logger.info("No more pages — finished.")
+            self.logger.info(f"[{property_category}/{status}] No more pages — finished.")
             return
 
         next_num = page_num + 1
-        self.logger.info(f"Queuing page {next_num}")
+        self.logger.info(f"[{property_category}/{status}] Queuing page {next_num}")
         yield scrapy.Request(
-            self._page_url(next_num),
+            self._page_url(base_url, next_num),
             headers=_HEADERS,
             meta=self._meta(),
             callback=self.parse,
-            cb_kwargs={'page_num': next_num},
+            cb_kwargs={'base_url': base_url, 'property_category': property_category, 'status': status, 'page_num': next_num},
             errback=self.errback,
         )
 
-    def _extract_item(self, ad, response):
+    def _extract_item(self, ad, response, property_category='house', status='sale'):
         item = self.make_item()
 
         relative_url = ad.attrib.get('href', '')
@@ -156,6 +166,13 @@ class Encuentra24Spider(BasePropertySpider):
 
         item['features'] = []
         item['metadata'] = {}
+
+        # status is always known from the crawl segment
+        item['status'] = status
+        # property_category is known for sale segments (typed URLs); for the catch-all
+        # rental URL it is None — dbt will infer from title
+        if property_category is not None:
+            item['property_category'] = property_category
 
         return item
 

--- a/homyscrapy/spiders/costa_rica/inhaus.py
+++ b/homyscrapy/spiders/costa_rica/inhaus.py
@@ -2,6 +2,37 @@ import re
 from scrapy.spiders import SitemapSpider
 from homyscrapy.spiders.base_spider import BasePropertySpider
 
+# Keywords used to classify operation type from title text (Spanish)
+_RENT_KEYWORDS = ('alquiler', 'alquila', 'arriendo', 'renta', 'rent')
+_SALE_KEYWORDS = ('venta', 'vende', 'sale', 'compra')
+
+# Keywords for property category from title text
+_CATEGORY_KEYWORDS = {
+    'house':      ('casa', 'house', 'home', 'residencia', 'villa', 'chalet'),
+    'apartment':  ('apartamento', 'apto', 'apartment', 'piso', 'condominio', 'condo', 'penthouse'),
+    'land':       ('lote', 'terreno', 'finca', 'parcela', 'land', 'lot'),
+    'commercial': ('local', 'comercial', 'oficina', 'bodega', 'commercial', 'office', 'retail'),
+}
+
+
+def _classify_from_title(title: str) -> tuple[str, str]:
+    """Return (property_category, status) inferred from the listing title."""
+    t = title.lower()
+
+    status = 'sale'  # default: InHaus is primarily a sale platform
+    for kw in _RENT_KEYWORDS:
+        if kw in t:
+            status = 'rent'
+            break
+
+    category = 'house'  # default
+    for cat, keywords in _CATEGORY_KEYWORDS.items():
+        if any(kw in t for kw in keywords):
+            category = cat
+            break
+
+    return category, status
+
 
 class InHausSpider(BasePropertySpider, SitemapSpider):
     name = 'inhaus'
@@ -38,6 +69,11 @@ class InHausSpider(BasePropertySpider, SitemapSpider):
         if id_match:
             item['external_id'] = id_match.group(1)
 
+        # Operation type from labeled attribute grid (e.g. "Tipo de operación: Alquiler")
+        # Falls back to title-based classification if not found in grid
+        status_from_grid = None
+        category_from_grid = None
+
         for grid_item in response.css('.grid.grid-cols-2.md\\:grid-cols-3 .bg-muted\\/50'):
             val = grid_item.css('.text-xl.font-bold ::text').get()
             lbl = grid_item.css('.text-sm.text-muted-foreground ::text').get()
@@ -52,6 +88,19 @@ class InHausSpider(BasePropertySpider, SitemapSpider):
                 item['area'] = val
             elif 'terreno' in lbl:
                 item['lot_area'] = val
+            elif 'operación' in lbl or 'operacion' in lbl:
+                status_from_grid = 'rent' if any(kw in val.lower() for kw in _RENT_KEYWORDS) else 'sale'
+            elif 'tipo' in lbl and 'propiedad' in lbl:
+                val_lower = val.lower()
+                for cat, keywords in _CATEGORY_KEYWORDS.items():
+                    if any(kw in val_lower for kw in keywords):
+                        category_from_grid = cat
+                        break
+
+        # Fall back to title parsing when grid doesn't expose these fields
+        category_from_title, status_from_title = _classify_from_title(item['title'])
+        item['property_category'] = category_from_grid or category_from_title
+        item['status'] = status_from_grid or status_from_title
 
         # Images — og:image + gallery; dict.fromkeys preserves order while deduplicating
         images = response.css('meta[property="og:image"]::attr(content)').getall()

--- a/homyscrapy/spiders/costa_rica/mls.py
+++ b/homyscrapy/spiders/costa_rica/mls.py
@@ -1,11 +1,23 @@
+import scrapy
 from homyscrapy.spiders.base_spider import BasePropertySpider
+
+# MLS is a Multiple Listing Service focused on sales. Each entry carries
+# a (url, property_category, status) tuple. Rental URL pattern (/search/ra)
+# is included but may return no results if MLS CR doesn't carry rental listings.
+_LISTING_URLS = [
+    ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=house&batch-limit=25&offset=0',       'house',      'sale'),
+    ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=apartment&batch-limit=25&offset=0',   'apartment',  'sale'),
+    ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=land&batch-limit=25&offset=0',        'land',       'sale'),
+    ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=commercial&batch-limit=25&offset=0',  'commercial', 'sale'),
+    ('https://mls.re.cr/search/ra?form.widgets.object_type%3Alist=house&batch-limit=25&offset=0',       'house',      'rent'),
+    ('https://mls.re.cr/search/ra?form.widgets.object_type%3Alist=apartment&batch-limit=25&offset=0',   'apartment',  'rent'),
+]
 
 
 class MLSSpider(BasePropertySpider):
     name = 'mls'
     source = 'MLS'
     allowed_domains = ['mls.re.cr']
-    start_urls = ['https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=house&batch-limit=25&offset=0']
 
     # Override global conservative defaults — MLS is a low-traffic static site
     custom_settings = {
@@ -14,9 +26,17 @@ class MLSSpider(BasePropertySpider):
         'CONCURRENT_REQUESTS': 2,
     }
 
-    def parse(self, response):
+    async def start(self):
+        for url, property_category, status in _LISTING_URLS:
+            yield scrapy.Request(
+                url,
+                callback=self.parse,
+                cb_kwargs={'property_category': property_category, 'status': status},
+            )
+
+    def parse(self, response, property_category='house', status='sale'):
         rows = response.css('tr')
-        self.logger.info(f"Found {len(rows)} rows")
+        self.logger.info(f"[{property_category}/{status}] Found {len(rows)} rows")
 
         for row in rows:
             if not row.css('td.title'):
@@ -25,22 +45,33 @@ class MLSSpider(BasePropertySpider):
             item = self.make_item()
             item['title'] = row.css('td.title a::text').get('').strip()
             item['price'] = row.css('td.price a::text').get('').strip()
-            item['status'] = row.css('td.workflow_state a::text').get('').strip()
             item['bedrooms'] = row.css('td.bedrooms a::text').get('').strip()
             item['bathrooms'] = row.css('td.bathrooms a::text').get('').strip()
             item['city'] = row.css('td.city a::text').get('').strip()
             item['state'] = row.css('td.state a::text').get('').strip()
             item['external_id'] = row.css('td.listing_id a::text').get('').strip()
             item['location_pcd'] = f"{item['city']}, {item['state']}"
+            # Set transaction type and property category from start URL — not from td.workflow_state
+            # (workflow_state carries listing state like "Active"/"Sold", not sale vs rent)
+            item['status'] = status
+            item['property_category'] = property_category
 
             detail_url = row.css('td.title a::attr(href)').get()
             if detail_url:
                 item['url'] = detail_url
-                yield response.follow(detail_url, callback=self.parse_property, meta={'item': item})
+                yield response.follow(
+                    detail_url,
+                    callback=self.parse_property,
+                    meta={'item': item},
+                )
 
         next_page = response.xpath("//a[contains(text(), 'Next')]/@href").get()
         if next_page:
-            yield response.follow(next_page, callback=self.parse)
+            yield response.follow(
+                next_page,
+                callback=self.parse,
+                cb_kwargs={'property_category': property_category, 'status': status},
+            )
 
     def parse_property(self, response):
         item = response.meta['item']

--- a/homyscrapy/spiders/costa_rica/mls.py
+++ b/homyscrapy/spiders/costa_rica/mls.py
@@ -1,16 +1,16 @@
 import scrapy
 from homyscrapy.spiders.base_spider import BasePropertySpider
 
-# MLS is a Multiple Listing Service focused on sales. Each entry carries
-# a (url, property_category, status) tuple. Rental URL pattern (/search/ra)
-# is included but may return no results if MLS CR doesn't carry rental listings.
+# MLS is a Multiple Listing Service. Sale listings live under /search/rs,
+# rental listings under /search/rl. Each entry carries a
+# (url, property_category, status) tuple.
 _LISTING_URLS = [
     ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=house&batch-limit=25&offset=0',       'house',      'sale'),
     ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=apartment&batch-limit=25&offset=0',   'apartment',  'sale'),
     ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=land&batch-limit=25&offset=0',        'land',       'sale'),
     ('https://mls.re.cr/search/rs?form.widgets.object_type%3Alist=commercial&batch-limit=25&offset=0',  'commercial', 'sale'),
-    ('https://mls.re.cr/search/ra?form.widgets.object_type%3Alist=house&batch-limit=25&offset=0',       'house',      'rent'),
-    ('https://mls.re.cr/search/ra?form.widgets.object_type%3Alist=apartment&batch-limit=25&offset=0',   'apartment',  'rent'),
+    ('https://mls.re.cr/search/rl?form.widgets.object_type%3Alist=house&batch-limit=25&offset=0',       'house',      'rent'),
+    ('https://mls.re.cr/search/rl?form.widgets.object_type%3Alist=apartment&batch-limit=25&offset=0',   'apartment',  'rent'),
 ]
 
 

--- a/homyscrapy/spiders/costa_rica/recr.py
+++ b/homyscrapy/spiders/costa_rica/recr.py
@@ -1,19 +1,59 @@
+import scrapy
 from homyscrapy.spiders.base_spider import BasePropertySpider
+
+_SALE_BASE = 'https://www.re.cr/en/costa-rica-real-estate-for-sale/search-properties'
+_RENT_BASE = 'https://www.re.cr/en/costa-rica-rental-properties'
+_SALE_PREFIX = '?form.search-properties.buttons.search='
+_RENT_PREFIX = '?form.search-properties.buttons.search='
+
+# Each entry: (url, property_category, status)
+# Rental URL uses the confirmed base: /en/costa-rica-rental-properties
+# The search param structure for rentals mirrors sales (listing_type=ra vs rs).
+_LISTING_URLS = [
+    # Sale: residential types
+    (
+        f'{_SALE_BASE}{_SALE_PREFIX}'
+        '&form.search-properties.widgets.object_type%3Alist=house'
+        '&form.search-properties.widgets.object_type%3Alist=mobile'
+        '&form.search-properties.widgets.object_type%3Alist=multiplex'
+        '&form.search-properties.widgets.object_type%3Alist=townhouse'
+        '&form.search-properties.widgets.listing_type=rs',
+        'house', 'sale',
+    ),
+    # Sale: apartments/condos
+    (
+        f'{_SALE_BASE}{_SALE_PREFIX}'
+        '&form.search-properties.widgets.object_type%3Alist=apartment'
+        '&form.search-properties.widgets.listing_type=rs',
+        'apartment', 'sale',
+    ),
+    # Sale: land/lots
+    (
+        f'{_SALE_BASE}{_SALE_PREFIX}'
+        '&form.search-properties.widgets.object_type%3Alist=land'
+        '&form.search-properties.widgets.listing_type=rs',
+        'land', 'sale',
+    ),
+    # Sale: commercial
+    (
+        f'{_SALE_BASE}{_SALE_PREFIX}'
+        '&form.search-properties.widgets.object_type%3Alist=commercial'
+        '&form.search-properties.widgets.listing_type=rs',
+        'commercial', 'sale',
+    ),
+    # Rent: catch-all (confirmed base URL; property_category inferred from listing)
+    (
+        f'{_RENT_BASE}{_RENT_PREFIX}'
+        '&form.search-properties.widgets.listing_type=ra',
+        None, 'rent',
+    ),
+]
 
 
 class RECRSpider(BasePropertySpider):
     name = 'recr'
     source = 'RE.CR'
     allowed_domains = ['re.cr', 'www.re.cr']
-    start_urls = [
-        'https://www.re.cr/en/costa-rica-real-estate-for-sale/search-properties'
-        '?form.search-properties.buttons.search='
-        '&form.search-properties.widgets.object_type%3Alist=house'
-        '&form.search-properties.widgets.object_type%3Alist=mobile'
-        '&form.search-properties.widgets.object_type%3Alist=multiplex'
-        '&form.search-properties.widgets.object_type%3Alist=townhouse'
-        '&form.search-properties.widgets.listing_type=rs'
-    ]
 
     # Override global conservative defaults — RE.CR is a low-traffic static site
     custom_settings = {
@@ -22,9 +62,17 @@ class RECRSpider(BasePropertySpider):
         'CONCURRENT_REQUESTS': 2,
     }
 
-    def parse(self, response):
+    async def start(self):
+        for url, property_category, status in _LISTING_URLS:
+            yield scrapy.Request(
+                url,
+                callback=self.parse,
+                cb_kwargs={'property_category': property_category, 'status': status},
+            )
+
+    def parse(self, response, property_category=None, status='sale'):
         tiles = response.css('div.tileItem')
-        self.logger.info(f"Found {len(tiles)} tiles")
+        self.logger.info(f"[{property_category}/{status}] Found {len(tiles)} tiles")
 
         for tile in tiles:
             title_link = tile.css('h2.tileHeadline a')
@@ -36,11 +84,19 @@ class RECRSpider(BasePropertySpider):
             item['title'] = title_link.css('::text').get('').strip()
             item['price'] = tile.css('.listing__price dd::text').get('').strip()
             item['url'] = detail_url
+            item['status'] = status
+            # Only set if known; catch-all rental segment leaves it to dbt title parsing
+            if property_category is not None:
+                item['property_category'] = property_category
             yield response.follow(detail_url, callback=self.parse_property, meta={'item': item})
 
         next_page = response.css('.next a::attr(href)').get()
         if next_page:
-            yield response.follow(next_page, callback=self.parse)
+            yield response.follow(
+                next_page,
+                callback=self.parse,
+                cb_kwargs={'property_category': property_category, 'status': status},
+            )
 
     def parse_property(self, response):
         item = response.meta['item']


### PR DESCRIPTION
## Summary
- Add multi-type URL segments (house, apartment, land, commercial) to **encuentra24**, **mls**, and **recr** spiders
- Add rental URL segments to **encuentra24** (catch-all `bienes-raices-alquiler`), **mls** (`/search/ra`), and **recr** (`/costa-rica-rental-properties`)
- Extract `property_category` and `status` (sale/rent) from **inhaus** HTML attribute grid with title-based fallback
- Set explicit `sale`/`rent` status on **cccbr** items based on which price field is populated
- All spiders pass `property_category` and `status` as `cb_kwargs` through the parse chain

## Test plan
- [ ] `scrapy crawl encuentra24 -s CLOSESPIDER_ITEMCOUNT=20` — confirm `status` and `property_category` populated
- [ ] `scrapy crawl mls -s CLOSESPIDER_ITEMCOUNT=20` — confirm rental items appear with `status=rent`
- [ ] `scrapy crawl recr -s CLOSESPIDER_ITEMCOUNT=20` — confirm rental items appear
- [ ] `scrapy crawl inhaus -s CLOSESPIDER_ITEMCOUNT=10` — confirm `property_category` extracted from HTML
- [ ] `scrapy crawl cccbr -s CLOSESPIDER_ITEMCOUNT=10` — confirm `status` field is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)