### PR TITLE
fix(ci): use GCP_SA_KEY for auth instead of WIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## Summary
- Switch `google-github-actions/auth@v2` from `workload_identity_provider` to `credentials_json` using existing `GCP_SA_KEY` secret
- The WIF secrets (`GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`) were never added to this repo, causing all deploy jobs to fail since PR #9

## Test plan
- [ ] CI passes lint + test on this PR
- [ ] After merge, the `Build, Push & Deploy` job on main succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)